### PR TITLE
Parametrize location of google secrets and token files

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,15 +13,23 @@ Using
 Set up a python virtualenv, activate it, and then install required modules
 with `pip install -r requirements.txt`.
 
-Create a new installed application in the [Google APIs console][console],
-with "Drive API" service enabled, download the `client_secrets.json` file
-and store it in `data/`, then run `python fetch_csv.py`. This will 
-authenticate against Google in your browser, then download the Service 
-Explorer detail to `data/services.csv`.
+### Fetching data
 
-Generate the site with `python create_pages.py`.
+* Create a new installed application in the [Google APIs console][console],
+with "Drive API" service enabled, download the `client_secrets.json` file
+and store it in `data/`
+* Run `python fetch_csv.py`. This will athenticate against Google in your browser, 
+then download the Service Explorer detail to `data/services.csv`. It can be 
+parametrized with the following arguments:
+  * `--client-secrets`: Google API client secrets JSON file (default: `data/client_secrets.json`)
+  * `--oauth-tokens`: Google API OAuth tokens file (default: `data/tokens.dat`)
 
 [console]: https://code.google.com/apis/console/
+
+### Generating site
+
+* Generate the site with `python create_pages.py`.
+
 
 
 Testing

--- a/fetch_csv.py
+++ b/fetch_csv.py
@@ -2,18 +2,18 @@
 
 import httplib2
 import os
-
+import sys
 from apiclient.discovery import build
 from oauth2client.client import flow_from_clientsecrets
 from oauth2client.file import Storage
 from oauth2client.tools import run
+from lib.params import parse_args_for_fetch
+
+arguments = parse_args_for_fetch(sys.argv[1:])
 
 SPREADSHEET = '0AiLXeWvTKFmBdFpxdEdHUWJCYnVMS0lnUHJDelFVc0E'
 SERVICES_SHEET = '44'
 SERVICES_DATA_OUTPUT = 'data/services.csv'
-
-CLIENT_SECRETS = 'data/client_secrets.json'
-OAUTH_TOKENS = 'data/tokens.dat'
 MISSING_CLIENT_SECRETS_MESSAGE = """
 WARNING: Please configure OAuth 2.0
 
@@ -24,16 +24,15 @@ found at:
 
 with information from the APIs Console <https://code.google.com/apis/console>.
 
-""" % os.path.join(os.path.dirname(__file__), CLIENT_SECRETS)
-
+""" % os.path.join(os.path.dirname(__file__), arguments.client_secrets)
 
 
 flow = flow_from_clientsecrets(
-    CLIENT_SECRETS,
+    arguments.client_secrets,
     scope='https://docs.google.com/feeds/ https://docs.googleusercontent.com/ https://spreadsheets.google.com/feeds/',
     message=MISSING_CLIENT_SECRETS_MESSAGE,
 )
-storage = Storage(OAUTH_TOKENS)
+storage = Storage(arguments.oauth_tokens)
 credentials = storage.get()
 if credentials is None or credentials.invalid:
   credentials = run(flow, storage)

--- a/lib/params/__init__.py
+++ b/lib/params/__init__.py
@@ -1,0 +1,4 @@
+import argparse
+
+def parse_args(args):
+    pass

--- a/lib/params/__init__.py
+++ b/lib/params/__init__.py
@@ -1,6 +1,6 @@
 import argparse
 
-def parse_args(args):
+def parse_args_for_fetch(args):
     parser = argparse.ArgumentParser()
     parser.add_argument('--client-secrets',
                         help='Google API client secrets JSON file',

--- a/lib/params/__init__.py
+++ b/lib/params/__init__.py
@@ -1,4 +1,12 @@
 import argparse
 
 def parse_args(args):
-    pass
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--client-secrets',
+                        help='Google API client secrets JSON file',
+                        default='data/client_secrets.json')
+    parser.add_argument('--oauth-tokens',
+                        help='Google API OAuth tokens file',
+                        default='data/tokens.dat')
+
+    return parser.parse_args(args)

--- a/test/params/test_arguments_parsing.py
+++ b/test/params/test_arguments_parsing.py
@@ -1,19 +1,21 @@
 import unittest
 from hamcrest import *
-from lib.params import parse_args
+from lib.params import parse_args_for_fetch
 
 
 class test_arguments_parsing(unittest.TestCase):
 
     def test_default_secret_and_token_to_data_dir(self):
-        argument = parse_args([])
+        argument = parse_args_for_fetch([])
 
         assert_that(argument.client_secrets, is_('data/client_secrets.json'))
         assert_that(argument.oauth_tokens, is_('data/tokens.dat'))
 
     def test_parse_secret_and_token_params(self):
-        argument = parse_args(['--client-secrets', '/var/google/secrets.json',
-                              '--oauth-tokens', '/var/google/token.dat'])
+        argument = parse_args_for_fetch(['--client-secrets',
+                                         '/var/google/secrets.json',
+                                         '--oauth-tokens',
+                                         '/var/google/token.dat'])
 
         assert_that(argument.client_secrets, is_('/var/google/secrets.json'))
         assert_that(argument.oauth_tokens, is_('/var/google/token.dat'))

--- a/test/params/test_arguments_parsing.py
+++ b/test/params/test_arguments_parsing.py
@@ -8,5 +8,5 @@ class test_arguments_parsing(unittest.TestCase):
     def test_default_secret_and_token_to_data_dir(self):
         argument = parse_args("")
 
-        assert_that(argument.client_secrets_file, is_('data/client_secrets.json'))
-        assert_that(argument.oath_tokens_file, is_('data/tokens.dat'))
+        assert_that(argument.client_secrets, is_('data/client_secrets.json'))
+        assert_that(argument.oauth_tokens, is_('data/tokens.dat'))

--- a/test/params/test_arguments_parsing.py
+++ b/test/params/test_arguments_parsing.py
@@ -1,0 +1,12 @@
+import unittest
+from hamcrest import *
+from lib.params import parse_args
+
+
+class test_arguments_parsing(unittest.TestCase):
+
+    def test_default_secret_and_token_to_data_dir(self):
+        argument = parse_args("")
+
+        assert_that(argument.client_secrets_file, is_('data/client_secrets.json'))
+        assert_that(argument.oath_tokens_file, is_('data/tokens.dat'))

--- a/test/params/test_arguments_parsing.py
+++ b/test/params/test_arguments_parsing.py
@@ -6,7 +6,14 @@ from lib.params import parse_args
 class test_arguments_parsing(unittest.TestCase):
 
     def test_default_secret_and_token_to_data_dir(self):
-        argument = parse_args("")
+        argument = parse_args([])
 
         assert_that(argument.client_secrets, is_('data/client_secrets.json'))
         assert_that(argument.oauth_tokens, is_('data/tokens.dat'))
+
+    def test_parse_secret_and_token_params(self):
+        argument = parse_args(['--client-secrets', '/var/google/secrets.json',
+                              '--oauth-tokens', '/var/google/token.dat'])
+
+        assert_that(argument.client_secrets, is_('/var/google/secrets.json'))
+        assert_that(argument.oauth_tokens, is_('/var/google/token.dat'))


### PR DESCRIPTION
The default location for these files is still the 'data' directory.

For deployment we want to be able to choose the location of files, which should be puppeted to a specific location.
