### PR TITLE
Add jasmine to tests - run automatically with nose

### DIFF
--- a/test/features/support/test_server.py
+++ b/test/features/support/test_server.py
@@ -11,13 +11,18 @@ import sys
 HTML_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                          '..', '..', '..', 'output'))
 
+SPEC_ROOT= os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                         '..', '..', '..', 'spec'))
 
 def has_extension(path):
     return bool(os.path.splitext(path)[1])
 
 
 def find_file_to_serve(path):
-    abs_path = os.path.join(HTML_ROOT, path.lstrip('/'))
+    if any(substring in path.lower() for substring in ('spec', 'jasmine')):
+        abs_path = os.path.join(SPEC_ROOT, path.lstrip('/'))
+    else:
+        abs_path = os.path.join(HTML_ROOT, path.lstrip('/'))
 
     if os.path.isdir(abs_path):
         abs_path = os.path.join(abs_path, 'index.html')

--- a/test/features/test_javascript.py
+++ b/test/features/test_javascript.py
@@ -1,0 +1,17 @@
+from hamcrest import *
+
+from test.features import BrowserTest
+from test.features.support import table_from
+
+
+class Javascript(BrowserTest):
+
+    def test_all_services_table(self):
+        self.browser.visit("http://0.0.0.0:8000/SpecRunner")
+        tests_passing = self.browser.find_by_css('.symbolSummary .passed')
+        tests_failing = self.browser.find_by_css('.symbolSummary .failed')
+
+        print 'Tests passing %s' % len(tests_passing)
+        print 'Tests failing %s' % len(tests_failing)
+
+        assert_that(len(tests_failing), is_(0))


### PR DESCRIPTION
*created a feature to check the number of passing jasmine tests during the nose run. Will fail if there are failures  and spit out numbers of passing/failing.

*possibly this shouldn't be in features or is just a bad idea altogether?
