### PR TITLE
Generate artefact with path prefix

### DIFF
--- a/build_artefact.sh
+++ b/build_artefact.sh
@@ -12,7 +12,10 @@ if [ -n "${CLIENT_SECRETS}" ]; then FETCH_ARGS="${FETCH_ARGS} --client-secrets $
 if [ -n "${OAUTH_TOKENS}" ];   then FETCH_ARGS="${FETCH_ARGS} --oauth-tokens ${OAUTH_TOKENS}"; fi
 
 python fetch_csv.py $FETCH_ARGS
-python create_pages.py
+
+if [ -n "${PATH_PREFIX}" ]; then CREATE_ARGS="${CREATE_ARGS} --path-prefix ${PATH_PREFIX}"; fi
+
+python create_pages.py $CREATE_ARGS
 
 cd output
 tar -zcvf ../artefacts/service-explorer.tgz .

--- a/build_artefact.sh
+++ b/build_artefact.sh
@@ -5,8 +5,8 @@ if [ -z "$VIRTUAL_ENV" ]; then
   exit 1
 fi
 
-mkdir -p artefacts
-rm -f artefacts/*
+mkdir -p artefacts; rm -f artefacts/*
+mkdir -p output; rm -Rf output/*
 
 if [ -n "${CLIENT_SECRETS}" ]; then FETCH_ARGS="${FETCH_ARGS} --client-secrets ${CLIENT_SECRETS}"; fi
 if [ -n "${OAUTH_TOKENS}" ];   then FETCH_ARGS="${FETCH_ARGS} --oauth-tokens ${OAUTH_TOKENS}"; fi

--- a/lib/filters/__init__.py
+++ b/lib/filters/__init__.py
@@ -123,5 +123,5 @@ def number_as_grouped_number(num):
         return locale.format('%d', num, grouping=True)
 
 def string_as_absolute_path(string):
-    return path_prefix + string
+    return path_prefix.rstrip('/') + '/' + string
 

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -1,4 +1,5 @@
 from hamcrest import assert_that, is_
+from lib import filters
 from lib.filters import number_as_magnitude, number_as_financial_magnitude, string_as_absolute_path
 
 
@@ -101,5 +102,23 @@ def test_number_as_financial_magnitude():
     assert_that(number_as_financial_magnitude(123400000000), is_("123bn"))
     assert_that(number_as_financial_magnitude(123600000000), is_("124bn"))
 
-def test_string_as_link():
-    assert_that(string_as_absolute_path('some/path'), is_('/some/path'))
+
+class Test_string_as_link:
+    def setUp(self):
+        self._default_path_prefix = filters.path_prefix
+
+    def tearDown(self):
+        filters.path_prefix = self._default_path_prefix
+
+    def test_string_as_link(self):
+        assert_that(string_as_absolute_path('some/path'), is_('/some/path'))
+
+    def test_string_as_link_with_user_defined_path_prefix(self):
+        filters.path_prefix = '/custom/prefix/'
+        assert_that(string_as_absolute_path('some/path'),
+                    is_('/custom/prefix/some/path'))
+
+    def test_string_as_link_adds_trailing_slash_after_prefix(self):
+        filters.path_prefix = '/custom/prefix'
+        assert_that(string_as_absolute_path('some/path'),
+                    is_('/custom/prefix/some/path'))


### PR DESCRIPTION
This allows setting the path prefix as an environment variable. Useful to generate artefacts with the appropriate path prefix from CI. 
