### PR TITLE
Dont blow up when no kpi

### DIFF
--- a/create_pages.py
+++ b/create_pages.py
@@ -69,10 +69,10 @@ if __name__ == "__main__":
     sort_orders = [
         ("by-name", lambda service: service.name_of_service),
         ("by-department", lambda service: service.abbr),
-        ("by-total-cost", lambda service: service.most_recent_kpis['cost']),
-        ("by-cost-per-transaction", lambda service: service.most_recent_kpis['cost_per_number']),
-        ("by-digital-takeup", lambda service: service.most_recent_kpis['takeup']),
-        ("by-transactions-per-year", lambda service: service.most_recent_kpis['volume_num']),
+        ("by-total-cost", lambda service: service.latest_kpi_for('cost')),
+        ("by-cost-per-transaction", lambda service: service.latest_kpi_for('cost_per_number')),
+        ("by-digital-takeup", lambda service: service.latest_kpi_for('takeup')),
+        ("by-transactions-per-year", lambda service: service.latest_kpi_for('volume_num')),
     ]
     generate_sorted_pages(high_volume_services, 'high-volume-services', 'high-volume-services',
                           sort_orders, {'latest_quarter': latest_quarter})

--- a/lib/service/__init__.py
+++ b/lib/service/__init__.py
@@ -8,7 +8,7 @@ from lib.slugify import keyify, slugify
 
 
 def latest_quarter(services):
-    return max(service.most_recent_kpis['quarter'] for service in services)
+    return max(service.latest_kpi_for('quarter') for service in services)
 
 
 def sorted_ignoring_empty_values(services, key, reverse=False):
@@ -128,14 +128,14 @@ class Service:
         return re.sub('\s*$', '', self.description_of_service)
 
     def latest_kpi_for(self, attribute):
-        latest_kpis = self.most_recent_kpis
+        latest_kpis = self._most_recent_kpis
         if latest_kpis is None:
             return None
         else:
-            return latest_kpis[attribute]
+            return latest_kpis.get(attribute)
 
     @property
-    def most_recent_kpis(self):
+    def _most_recent_kpis(self):
         if len(self.kpis) > 0:
             return self.kpis[-1]
 
@@ -169,7 +169,7 @@ class Service:
     def most_up_to_date_volume(self):
         most_recent_yearly_volume = None
         if self.has_kpis:
-            most_recent_yearly_volume = self.most_recent_kpis['volume_num']
+            most_recent_yearly_volume = self.latest_kpi_for('volume_num')
         return most_recent_yearly_volume
 
     def historical_data(self, key):
@@ -335,7 +335,7 @@ def total_transaction_volume(services):
     def _sum(memo, service):
         number_of_transactions = 0
         if service.has_kpis:
-            number_of_transactions = service.most_recent_kpis['volume_num']
+            number_of_transactions = service.latest_kpi_for('volume_num')
         return number_of_transactions + memo
 
     return reduce(_sum, services, 0)

--- a/lib/service/__init__.py
+++ b/lib/service/__init__.py
@@ -8,7 +8,7 @@ from lib.slugify import keyify, slugify
 
 
 def latest_quarter(services):
-    return max(service.latest_kpi_for('quarter') for service in services)
+    return max(service.latest_kpi_for('quarter') for service in services if service.has_kpis)
 
 
 def sorted_ignoring_empty_values(services, key, reverse=False):

--- a/lib/service/__init__.py
+++ b/lib/service/__init__.py
@@ -152,7 +152,7 @@ class Service:
     def _attributes_present(self, kpi, attrs):
         return all(kpi[attr] is not None for attr in attrs)
 
-    def most_recent_kpis_with(self, attrs):
+    def find_recent_kpis_with_attributes(self, attrs):
         return next((kpi for kpi in reversed(self.kpis)
                      if self._attributes_present(kpi, attrs)),
                     None)
@@ -317,14 +317,14 @@ class ServiceKpiAggregator(object):
 
     def aggregate(self, attrs, high_volume_only=False):
         def included(service):
-            return service.most_recent_kpis_with(attrs) is not None and (
+            return service.find_recent_kpis_with_attributes(attrs) is not None and (
                    not high_volume_only or service.high_volume)
 
         def aggregation(attr):
-            values = [service.most_recent_kpis_with(attrs)[attr]
+            values = [service.find_recent_kpis_with_attributes(attrs)[attr]
                       for service in self.services
                       if included(service)
-                      and service.most_recent_kpis_with(attrs)[attr] is not None]
+                      and service.find_recent_kpis_with_attributes(attrs)[attr] is not None]
             if any(values):
                 return sum(values)
 

--- a/lib/service/__init__.py
+++ b/lib/service/__init__.py
@@ -127,6 +127,13 @@ class Service:
     def description(self):
         return re.sub('\s*$', '', self.description_of_service)
 
+    def latest_kpi_for(self, attribute):
+        latest_kpis = self.most_recent_kpis
+        if latest_kpis is None:
+            return None
+        else:
+            return latest_kpis[attribute]
+
     @property
     def most_recent_kpis(self):
         if len(self.kpis) > 0:

--- a/templates/kpi_item.html
+++ b/templates/kpi_item.html
@@ -10,13 +10,13 @@
     {% else %}
       <h2>{{ value|as_magnitude }}</h2>
     {% endif %}
-    <h3>{{ service.most_recent_kpis.quarter }}</h3>
+    <h3>{{ service.latest_kpi_for('quarter') }}</h3>
   </div>
   
   {% if service.has_previous_quarter and change is not none %}
     <div class="change col-35">
       <h2 class="{% if change != 0 %}{% if change < 1 %}decrease {{decrease_class}}{% elif change > 1 %}increase {{increase_class}}{% endif %}{% endif %}">{{ change|as_percentage_change }}</h2>
-      <h3>{{ service.most_recent_kpis.previous_quarter }}</h3>
+      <h3>{{ service.latest_kpi_for('previous_quarter') }}</h3>
     </div>
     <div class="previous clear-div">
       <details>

--- a/templates/service_detail.html
+++ b/templates/service_detail.html
@@ -50,12 +50,12 @@
           <div class="kpi">
           
             {# TRANSACTIONS PER YEAR #}
-            {% if service.most_recent_kpis.volume is not none %}
+            {% if service.latest_kpi_for('volume') is not none %}
               {% with %}
                 {% set title='Transactions per year' %}
                 {% set key='volume' %}
-                {% set value=service.most_recent_kpis.volume %}
-                {% set change=service.most_recent_kpis.volume_change %}
+                {% set value=service.latest_kpi_for('volume') %}
+                {% set change=service.latest_kpi_for('volume_change') %}
                 {% set increase_class='green' %}
                 {% set decrease_class='red' %}
                 {% include "kpi_item.html" %}
@@ -63,13 +63,13 @@
             {% endif %}
           
             {# DIGITAL TAKE-UP #}
-            {% if service.most_recent_kpis.takeup is not none %}
+            {% if service.latest_kpi_for('takeup') is not none %}
               {% with %}
                 {% set title='Digital take-up' %}
                 {% set key='takeup' %}
-                {% set value=service.most_recent_kpis.takeup %}
+                {% set value=service.latest_kpi_for('takeup') %}
                 {% set value_type='percentage' %}
-                {% set change=service.most_recent_kpis.takeup_change %}
+                {% set change=service.latest_kpi_for('takeup_change') %}
                 {% set increase_class='green' %}
                 {% set decrease_class='red' %}
                 {% include "kpi_item.html" %}
@@ -78,30 +78,30 @@
             {% endif %}
           
             {# TOTAL COST #}
-            {% if service.most_recent_kpis.takeup is not none %}
+            {% if service.latest_kpi_for('takeup') is not none %}
               {% with %}
                 {% set title='Total Cost' %}
                 {% set key='cost' %}
-                {% set value=service.most_recent_kpis.cost %}
+                {% set value=service.latest_kpi_for('cost') %}
                 {% set value_type='money' %}
-                {% set change=service.most_recent_kpis.cost_change %}
+                {% set change=service.latest_kpi_for('cost_change') %}
                 {% set increase_class='red' %}
                 {% set decrease_class='green' %}
                 {% include "kpi_item.html" %}
               {% endwith %}
-              {% if not service.most_recent_kpis.cost_per %}
+              {% if not service.latest_kpi_for('cost_per') %}
                 <div class="clear-div"></div>
               {% endif %}
             {% endif %}
           
             {# COST PER TRANSACTION #}
-            {% if service.most_recent_kpis.cost_per_number is not none %}
+            {% if service.latest_kpi_for('cost_per_number') is not none %}
               {% with %}
                 {% set title='Cost per transaction' %}
                 {% set key='cost_per' %}
-                {% set value=service.most_recent_kpis.cost_per_number %}
+                {% set value=service.latest_kpi_for('cost_per_number') %}
                 {% set value_type='money' %}
-                {% set change=service.most_recent_kpis.cost_per_change %}
+                {% set change=service.latest_kpi_for('cost_per_change') %}
                 {% set increase_class='red' %}
                 {% set decrease_class='green' %}
                 {% include "kpi_item.html" %}

--- a/templates/service_table.html
+++ b/templates/service_table.html
@@ -55,8 +55,8 @@
     <tbody>
         {% for service in items %}
 
-            <tr data-volume="{{ service.most_recent_kpis.volume_num|int }}"
-                data-volumeLabel=" {{ service.most_recent_kpis.volume_num|as_grouped_number }} "
+            <tr data-volume="{{ service.latest_kpi_for('volume_num')|int }}"
+                data-volumeLabel=" {{ service.latest_kpi_for('volume_num')|as_grouped_number }} "
                 data-category="{{ service.category }}"
                 data-body="{{ service.body }}"
                 data-body-abbr="{{ service.agency_abbr }}"
@@ -76,26 +76,26 @@
                 <td>{{ service.abbr }}</td>
 
                 <td class="amount">
-                    {{ cell_content(quarter=service.most_recent_kpis['quarter'],
-                                    value=service.most_recent_kpis.cost,
+                    {{ cell_content(quarter=service.latest_kpi_for('quarter'),
+                                    value=service.latest_kpi_for('cost'),
                                     cell_format=table.money_cell) }}
                 </td>
 
                 <td class="amount">
-                    {{ cell_content(quarter=service.most_recent_kpis['quarter'],
-                                    value=service.most_recent_kpis.cost_per_number,
+                    {{ cell_content(quarter=service.latest_kpi_for('quarter'),
+                                    value=service.latest_kpi_for('cost_per_number'),
                                     cell_format=table.money_cell) }}
                 </td>
 
                 <td class="amount">
-                    {{ cell_content(quarter=service.most_recent_kpis['quarter'],
-                                    value=service.most_recent_kpis.takeup,
+                    {{ cell_content(quarter=service.latest_kpi_for('quarter'),
+                                    value=service.latest_kpi_for('takeup'),
                                     cell_format=table.percentage_cell) }}
                 </td>
 
                 <td class="amount">
-                    {{ cell_content(quarter=service.most_recent_kpis['quarter'],
-                                    value=service.most_recent_kpis.volume_num,
+                    {{ cell_content(quarter=service.latest_kpi_for('quarter'),
+                                    value=service.latest_kpi_for('volume_num'),
                                     cell_format=table.number_cell) }}
                 </td>
 

--- a/test/service/test_service.py
+++ b/test/service/test_service.py
@@ -51,6 +51,14 @@ class TestService(unittest.TestCase):
 
         assert_that(service.latest_kpi_for('volume_num'), is_(None))
 
+    def test_kpi_with_missing_property(self):
+        service = Service(details({
+           '2012-Q4 Vol.': '5'
+        }))
+
+        assert_that(service.latest_kpi_for('volume_change'), is_(None))
+
+
     def test_most_recent_kpi_with_given_attribute(self):
         service = Service(details({
             '2012-Q4 Vol.': '10',

--- a/test/service/test_service.py
+++ b/test/service/test_service.py
@@ -66,7 +66,7 @@ class TestService(unittest.TestCase):
             '2013-Q1 Vol.': '3',
         }))
 
-        assert_that(service.most_recent_kpis_with(['volume_num', 'digital_volume_num'])['volume_num'],
+        assert_that(service.find_recent_kpis_with_attributes(['volume_num', 'digital_volume_num'])['volume_num'],
                     is_(10))
 
     def test_most_recent_kpi_with_attributes_are_none_if_no_attributes_are_present(self):
@@ -75,7 +75,7 @@ class TestService(unittest.TestCase):
             '2013-Q1 Vol.': '3',
         }))
 
-        assert_that(service.most_recent_kpis_with(['volume_num', 'digital_volume_num']),
+        assert_that(service.find_recent_kpis_with_attributes(['volume_num', 'digital_volume_num']),
                     is_(None))
 
 

--- a/test/service/test_service.py
+++ b/test/service/test_service.py
@@ -23,35 +23,33 @@ class TestService(unittest.TestCase):
         service = Service(details({'2012-Q4 Vol.': '0',
                                    '2012-Q4 Digital vol.': '0'}))
 
-        assert_that(service.most_recent_kpis['takeup'],
+        assert_that(service.latest_kpi_for('takeup'),
                     is_(None))
 
     def test_volumes(self):
         service = Service(details({'2012-Q4 Vol.': '10',
                                    '2012-Q4 Digital vol.': '5'}))
 
-        assert_that(service.most_recent_kpis['takeup'], is_(0.5))
+        assert_that(service.latest_kpi_for('takeup'), is_(0.5))
  
     def test_most_recent_kpi_takeup_is_none_if_no_matching_quarters(self):
         service = Service(details({'2012-Q4 Vol.': '10',
                                    '2013-Q1 Digital vol.': '5'}))
 
-        assert_that(service.most_recent_kpis['takeup'],
+        assert_that(service.latest_kpi_for('takeup'),
                     is_(None))
 
     def test_no_kpis(self):
         service = Service(details({}))
 
-        assert_that(service.most_recent_kpis,
-                    is_(None))
+        assert_that(service.latest_kpi_for('takeup'), is_(None))
 
     def test_no_kpi_for_quarter_with_noVolume(self):
         service = Service(details({
            '2012-Q4 Digital vol.': '5'
         }))
 
-        assert_that(service.most_recent_kpis,
-                    is_(None))
+        assert_that(service.latest_kpi_for('volume_num'), is_(None))
 
     def test_most_recent_kpi_with_given_attribute(self):
         service = Service(details({
@@ -79,23 +77,19 @@ class TestService(unittest.TestCase):
             u'2012-Q4 CPT (\xa3)': "2.00"
         }))
 
-        pprint(service.most_recent_kpis)
-
-        assert_that(service.most_recent_kpis['cost'], is_(4000))
+        assert_that(service.latest_kpi_for('cost'), is_(4000))
 
     def test_cost_is_non_when_no_cpt(self):
         service = Service(details({
             "2012-Q4 Vol.": "2,000",
         }))
 
-        pprint(service.most_recent_kpis)
-
-        assert_that(service.most_recent_kpis['cost'], is_(None))
+        assert_that(service.latest_kpi_for('cost'), is_(None))
 
     def test_transactions_count(self):
         service = Service(details({'2013-Q1 Vol.': '10'}))
 
-        assert_that(service.most_recent_kpis['volume_num'], is_(10))
+        assert_that(service.latest_kpi_for('volume_num'), is_(10))
 
     def test_coverage(self):
         service = Service(details({


### PR DESCRIPTION
I've replaced the usage of `most_recent_kpis` method, which returns the Dict, to `latest_kpi_for`, which returns the actual attribute.
