### PR TITLE
Generate static urls with digest

### DIFF
--- a/build_artefact.sh
+++ b/build_artefact.sh
@@ -8,6 +8,8 @@ fi
 mkdir -p artefacts; rm -f artefacts/*
 mkdir -p output; rm -Rf output/*
 
+curl https://assets.digital.cabinet-office.gov.uk/static/manifest.yml > data/static-digests.yml
+
 if [ -n "${CLIENT_SECRETS}" ]; then FETCH_ARGS="${FETCH_ARGS} --client-secrets ${CLIENT_SECRETS}"; fi
 if [ -n "${OAUTH_TOKENS}" ];   then FETCH_ARGS="${FETCH_ARGS} --oauth-tokens ${OAUTH_TOKENS}"; fi
 
@@ -15,6 +17,7 @@ python fetch_csv.py $FETCH_ARGS
 
 if [ -n "${PATH_PREFIX}" ]; then CREATE_ARGS="${CREATE_ARGS} --path-prefix ${PATH_PREFIX}"; fi
 if [ -n "${ASSET_PREFIX}" ]; then CREATE_ARGS="${CREATE_ARGS} --asset-prefix ${ASSET_PREFIX}"; fi
+CREATE_ARGS="${CREATE_ARGS} --static-digests data/static-digests.yml"
 
 python create_pages.py $CREATE_ARGS
 

--- a/create_pages.py
+++ b/create_pages.py
@@ -3,6 +3,7 @@ import sys
 from distutils import dir_util
 
 import unicodecsv
+from lib.filters import digest
 from lib.params import parse_args_for_create
 
 from lib.service import Service, latest_quarter, sorted_ignoring_empty_values, Department
@@ -10,8 +11,7 @@ from lib.service import Service, latest_quarter, sorted_ignoring_empty_values, D
 from lib import templates, filters
 from lib.csv import map_services_to_csv_data, map_services_to_dicts
 
-from lib.service import Service, latest_quarter, sorted_ignoring_empty_values,\
-    total_transaction_volume
+from lib.service import total_transaction_volume
 from lib.slugify import slugify
 from lib.templates import render, render_csv, render_search_json
 
@@ -25,6 +25,9 @@ input = arguments.services_data
 
 filters.path_prefix = arguments.path_prefix
 filters.asset_prefix = arguments.asset_prefix
+
+if arguments.static_digests:
+    digest.load_digests(arguments.static_digests)
 
 data = open(input)
 

--- a/lib/filters/__init__.py
+++ b/lib/filters/__init__.py
@@ -1,7 +1,8 @@
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 import locale
 
-from re import match, sub
+from re import sub
+from lib.filters import digest
 
 
 NO_DECIMAL_PLACE = Decimal('1')
@@ -13,6 +14,7 @@ locale.setlocale(locale.LC_ALL, 'en_GB.utf-8')
 
 path_prefix = '/'
 asset_prefix = '/assets/'
+static_prefix = 'https://assets.digital.cabinet-office.gov.uk/static'
 
 
 def as_number(num):
@@ -125,6 +127,10 @@ def string_as_absolute_url(string):
 
 def string_as_asset_url(string):
     return join_url_parts(asset_prefix, string)
+
+
+def string_as_static_url(string):
+    return join_url_parts(static_prefix, digest.digest(string))
 
 
 def join_url_parts(prefix, suffix):

--- a/lib/filters/digest.py
+++ b/lib/filters/digest.py
@@ -1,0 +1,17 @@
+import yaml
+
+
+_digests = {}
+
+
+def load_digests(input):
+    set_digests(yaml.load(input))
+
+
+def set_digests(digests):
+    global _digests
+    _digests = digests or {}
+
+
+def digest(asset):
+    return _digests.get(asset, asset)

--- a/lib/params/__init__.py
+++ b/lib/params/__init__.py
@@ -30,5 +30,8 @@ def parse_args_for_create(args):
     parser.add_argument('--asset-prefix',
                         help='Prefix for generated asset URLs',
                         default=filters.asset_prefix)
+    parser.add_argument('--static-digests',
+                        help='Path to manifest file containing assets digests',
+                        type=argparse.FileType())
 
     return parser.parse_args(args)

--- a/lib/templates/__init__.py
+++ b/lib/templates/__init__.py
@@ -16,7 +16,6 @@ jinja = Environment(
     extensions=['jinja2.ext.with_']
 )
 
-jinja.globals['STATIC_HOST'] = 'https://assets.digital.cabinet-office.gov.uk/static'
 jinja.globals['CSV_LOCATION'] = '/transaction-volumes.csv'
 jinja.globals['GA_ACCOUNT'] = 'UA-36369871-1'
 jinja.globals['GA_DOMAIN'] = 'gov.uk'
@@ -28,6 +27,7 @@ jinja.filters['as_percentage_change'] = number_as_percentage_change
 jinja.filters['as_grouped_number'] = number_as_grouped_number
 jinja.filters['as_absolute_url'] = string_as_absolute_url
 jinja.filters['as_asset_url'] = string_as_asset_url
+jinja.filters['as_static_url'] = string_as_static_url
 jinja.filters['slugify'] = slugify
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ oauth2client==1.1
 unicodecsv==0.9.4
 simplejson==3.3.0
 scrapy==0.18
+pyyaml==3.10
 # test code requirements
 nose
 pyhamcrest

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,38 +6,38 @@
     <script type="text/javascript">
         (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
     </script><!--[if gt IE 8]><!-->
-    <link href="{{ STATIC_HOST }}/application.css" media="screen" rel="stylesheet" type="text/css">
-    <!--<![endif]--><!--[if IE 6]><link href="{{ STATIC_HOST }}/application-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]--><!--[if IE 7]><link href="{{ STATIC_HOST }}/application-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]--><!--[if IE 8]><link href="{{ STATIC_HOST }}/application-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]--><link href="{{ STATIC_HOST }}/print.css" media="print" rel="stylesheet" type="text/css">
+    <link href="{{ 'application.css' | as_static_url }}" media="screen" rel="stylesheet" type="text/css">
+    <!--<![endif]--><!--[if IE 6]><link href="{{ 'application-ie6.css' | as_static_url }}" media="screen" rel="stylesheet" type="text/css" /><![endif]--><!--[if IE 7]><link href="{{ 'application-ie7.css' | as_static_url }}" media="screen" rel="stylesheet" type="text/css" /><![endif]--><!--[if IE 8]><link href="{{ 'application-ie8.css' | as_static_url }}" media="screen" rel="stylesheet" type="text/css" /><![endif]--><link href="{{ 'print.css' | as_static_url }}" media="print" rel="stylesheet" type="text/css">
     <!--[if IE 8]>
     <script type="text/javascript">
         (function(){if(window.opera){return;}
         setTimeout(function(){var a=document,g,b={families:(g=
-        ["nta"]),urls:["{{ STATIC_HOST }}/fonts-ie8.css"]},
-        c="{{ STATIC_HOST }}/libs/goog/webfont-debug.js",d="script",
+        ["nta"]),urls:["{{ 'fonts-ie8.css' | as_static_url }}"]},
+        c="{{ 'libs/goog/webfont-debug.js' | as_static_url }}",d="script",
         e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
         ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
         .className+=' wf-'+g[h].replace(/\s/g,'').toLowerCase()+'-n4-loading');},0)
         })()
     </script>
-    <![endif]--><!--[if gte IE 9]><!--><link href="{{ STATIC_HOST }}/fonts.css" media="all" rel="stylesheet" type="text/css">
+    <![endif]--><!--[if gte IE 9]><!--><link href="{{ 'fonts.css' | as_static_url }}" media="all" rel="stylesheet" type="text/css">
     <!--<![endif]--><!--[if lt IE 9]>
-    <script src="{{ STATIC_HOST }}/ie.js" type="text/javascript"></script>
-    <![endif]--><link rel="shortcut icon" href="{{ STATIC_HOST }}/favicon.ico" type="image/x-icon">
-    <!-- For third-generation iPad with high-resolution Retina display: --><link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ STATIC_HOST }}/apple-touch-icon-144x144.png">
-    <!-- For iPhone with high-resolution Retina display: --><link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ STATIC_HOST }}/apple-touch-icon-114x114.png">
-    <!-- For first- and second-generation iPad: --><link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ STATIC_HOST }}/apple-touch-icon-72x72.png">
-    <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: --><link rel="apple-touch-icon-precomposed" href="{{ STATIC_HOST }}/apple-touch-icon-57x57.png">
+    <script src="{{ 'ie.js' | as_static_url }}" type="text/javascript"></script>
+    <![endif]--><link rel="shortcut icon" href="{{ 'favicon.ico' | as_static_url }}" type="image/x-icon">
+    <!-- For third-generation iPad with high-resolution Retina display: --><link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ 'apple-touch-icon-144x144.png' | as_static_url }}">
+    <!-- For iPhone with high-resolution Retina display: --><link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ 'apple-touch-icon-114x114.png' | as_static_url }}">
+    <!-- For first- and second-generation iPad: --><link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ 'apple-touch-icon-72x72.png' | as_static_url }}">
+    <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: --><link rel="apple-touch-icon-precomposed" href="{{ 'apple-touch-icon-57x57.png' | as_static_url }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="og:image" content="{{ STATIC_HOST }}/opengraph-image.png">
-    <script src="{{ STATIC_HOST }}/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script><script defer src="{{ STATIC_HOST }}/application.js" type="text/javascript"></script>
+    <meta name="og:image" content="{{ 'opengraph-image.png' | as_static_url }}">
+    <script src="{{ 'libs/jquery/jquery-1.7.2.js' | as_static_url }}" type="text/javascript"></script><script defer src="{{ 'application.js' | as_static_url }}" type="text/javascript"></script>
     {% include "google-analytics.html" %}
     <link rel="stylesheet" media="screen" href="{{ 'stylesheets/index.css' | as_asset_url }}">
     <link rel="stylesheet" media="screen" href="{{ 'stylesheets/treemap.css' | as_asset_url }}">
     <!--[if lt IE 9]>
-    <link type="text/css" href="{{ STATIC_HOST }}/ie.css" rel="stylesheet" media="all">
+    <link type="text/css" href="{{ 'ie.css' | as_static_url }}" rel="stylesheet" media="all">
     <![endif]-->
     <!--[if lt IE 7]>
-    <link type="text/css" href="{{ STATIC_HOST }}/ie-more.css" rel="stylesheet" media="all">
+    <link type="text/css" href="{{ 'ie-more.css' | as_static_url }}" rel="stylesheet" media="all">
     <![endif]-->
 </head>
     <body class="">
@@ -49,7 +49,7 @@
             <div class="header-global">
                 <div class="header-logo">
                     <a href="/" title="Go to the GOV.UK homepage" id="logo" class="content">
-                        <img src="{{ STATIC_HOST }}/gov.uk_logotype-2x.png" alt="GOV.UK">
+                        <img src="{{ 'gov.uk_logotype-2x.png' | as_static_url }}" alt="GOV.UK">
                     </a>
                 </div>
             </div>

--- a/test/filters/test_digest.py
+++ b/test/filters/test_digest.py
@@ -1,0 +1,25 @@
+from hamcrest import assert_that, is_
+from lib.filters import digest
+
+
+class TestDigest:
+    def setUp(self):
+        digest.set_digests(None)
+
+    def test_load_digests_in_yaml_format(self):
+        digests = """
+            asset.type: asset-4678abfe2.type
+        """
+
+        digest.load_digests(digests)
+
+        assert_that(
+            digest.digest('asset.type'),
+            is_('asset-4678abfe2.type')
+        )
+
+    def test_return_plain_asset_if_digest_is_unknown(self):
+        assert_that(
+            digest.digest('unregistered_asset.js'),
+            is_('unregistered_asset.js')
+        )

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -1,5 +1,5 @@
 from hamcrest import assert_that, is_
-from lib.filters import number_as_magnitude, number_as_financial_magnitude, join_url_parts, number_as_grouped_number
+from lib.filters import number_as_magnitude, number_as_financial_magnitude, join_url_parts, string_as_static_url, digest, number_as_grouped_number
 
 
 def test_number_as_magnitude():
@@ -130,3 +130,23 @@ class Test_join_url_parts(object):
         assert_that(
             join_url_parts('/custom/prefix/', '/some/path'),
             is_('/custom/prefix/some/path'))
+
+
+class Test_string_as_static_url:
+    def setUp(self):
+        digest.set_digests({})
+
+    def test_return_url_with_digest(self):
+        digest.set_digests({
+            'asset.css': 'asset-1425361275412.css'
+        })
+        assert_that(
+            string_as_static_url('asset.css'),
+            is_('https://assets.digital.cabinet-office.gov.uk/static/asset-1425361275412.css')
+        )
+
+    def test_fallback_to_plain_url_when_digest_is_unknown(self):
+        assert_that(
+            string_as_static_url('asset.css'),
+            is_('https://assets.digital.cabinet-office.gov.uk/static/asset.css')
+        )

--- a/test/params/test_arguments_parsing.py
+++ b/test/params/test_arguments_parsing.py
@@ -21,7 +21,6 @@ class FetchArgumentParsing(unittest.TestCase):
         assert_that(argument.oauth_tokens, is_('/var/google/token.dat'))
 
 
-
 class CreateArgumentParsing(unittest.TestCase):
 
     def test_default_services_data_file_and_prefix_on_data_dir(self):


### PR DESCRIPTION
- introduce a helper method to generate URLs to assets served by static
- generate static URLs with digest if the manifest is available
- in artefact build, retrieve the current digests manifest and use it to create the pages
