### PR TITLE
Fix misaligned header caused by changes in static project

### DIFF
--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -1651,6 +1651,10 @@ article.service-details section h2 {
   background-color: yellow; }
 
 
+header.page-header div {
+  margin: 0;
+  padding: 0;
+}
 
 span.alpha-tag {
   text-transform: uppercase;


### PR DESCRIPTION
Additional margin and padding were inherited from a rule in static.
This caused headers to be misplaced and hide the department images.
