### PR TITLE
Fix footer logo

### DIFF
--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -1082,11 +1082,6 @@ article .table-margin {
 #content * {
   font-family: ntatabularnumbers, nta, arial, sans-serif; }
 
-/* line 50, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/index.scss */
-footer#footer div.footer-wrapper div.footer-meta {
-  border: none;
-  margin: 0; }
-
 /* line 57, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/index.scss */
 header.page-header hgroup {
   margin: 0;

--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -1087,10 +1087,6 @@ footer#footer div.footer-wrapper div.footer-meta {
   border: none;
   margin: 0; }
 
-/* line 54, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/index.scss */
-footer#footer .footer-meta .copyright a {
-  background: transparent url(https://assets.digital.cabinet-office.gov.uk/static/govuk-crest-795cd6afb205d81a4267e100e11debe1.png) no-repeat 50% 0; }
-
 /* line 57, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/index.scss */
 header.page-header hgroup {
   margin: 0;

--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -87,11 +87,6 @@
 .performance-hidden {
   display: none; }
 
-/* line 15, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/layout.scss */
-#wrapper {
-  max-width: 1020px;
-  margin: 0 auto; }
-
 /* line 20, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/layout.scss */
 #wrapper * {
   -webkit-box-sizing: border-box;
@@ -1746,4 +1741,9 @@ nav.performance-nav a:hover {
 
 #search-box {
   min-width: 20em;
+}
+
+#wrapper {
+  margin: 0 auto;
+  border-bottom-color: #097f96;
 }


### PR DESCRIPTION
General changes to make the footer match the Performance Platform pages (e.g. https://www.preview.alphagov.co.uk/performance/services):
- Fix footer logo to be aligned to the copyright notice
- Add vertical divider
- Bottom bar should match color and width
