### PR TITLE
Make build scripts more modular

### DIFF
--- a/build_artefact.sh
+++ b/build_artefact.sh
@@ -8,13 +8,6 @@ fi
 mkdir -p artefacts; rm -f artefacts/*
 mkdir -p output; rm -Rf output/*
 
-curl https://assets.digital.cabinet-office.gov.uk/static/manifest.yml > data/static-digests.yml
-
-if [ -n "${CLIENT_SECRETS}" ]; then FETCH_ARGS="${FETCH_ARGS} --client-secrets ${CLIENT_SECRETS}"; fi
-if [ -n "${OAUTH_TOKENS}" ];   then FETCH_ARGS="${FETCH_ARGS} --oauth-tokens ${OAUTH_TOKENS}"; fi
-
-python fetch_csv.py $FETCH_ARGS
-
 if [ -n "${PATH_PREFIX}" ]; then CREATE_ARGS="${CREATE_ARGS} --path-prefix ${PATH_PREFIX}"; fi
 if [ -n "${ASSET_PREFIX}" ]; then CREATE_ARGS="${CREATE_ARGS} --asset-prefix ${ASSET_PREFIX}"; fi
 CREATE_ARGS="${CREATE_ARGS} --static-digests data/static-digests.yml"
@@ -22,4 +15,4 @@ CREATE_ARGS="${CREATE_ARGS} --static-digests data/static-digests.yml"
 python create_pages.py $CREATE_ARGS
 
 cd output
-tar -zcvf ../artefacts/transactions-explorer.tgz .
+tar -zcvf "../artefacts/${ARTEFACT_NAME}" .

--- a/fetch_data.sh
+++ b/fetch_data.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+if [ -z "$VIRTUAL_ENV" ]; then
+    echo "ERROR: You are not running within a virtual environment" >&2
+    exit 1
+fi
+
+if [ -n "${CLIENT_SECRETS}" ]; then FETCH_ARGS="${FETCH_ARGS} --client-secrets ${CLIENT_SECRETS}"; fi
+if [ -n "${OAUTH_TOKENS}" ];   then FETCH_ARGS="${FETCH_ARGS} --oauth-tokens ${OAUTH_TOKENS}"; fi
+
+python fetch_csv.py $FETCH_ARGS
+
+curl https://assets.digital.cabinet-office.gov.uk/static/manifest.yml > data/static-digests.yml
+
+

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eo pipefail
-
-. ./create_virtualenv.sh $VIRTUALENV_NAME
-./build_artefact.sh


### PR DESCRIPTION
- separate fetch_data.sh from build_artefact.sh
- artefact name now parametric

This allows building multiple artefacts with different configurations,
sharing the same source data
