### PR TITLE
Fix data coverage calculation

### DIFF
--- a/lib/service/__init__.py
+++ b/lib/service/__init__.py
@@ -18,12 +18,13 @@ def sorted_ignoring_empty_values(services, key, reverse=False):
 
 
 class Service:
-    valid_quarters = [
+    EXPECTED_QUARTERS = [
         # worked through oldest to newest to calculate %age changes
         '2012_q4',
         '2013_q1',
         '2013_q2',
     ]
+    COVERAGE_ATTRIBUTES = ['digital_volume_num', 'volume_num', 'cost']
 
     def __init__(self, details):
         for key in details:
@@ -37,7 +38,7 @@ class Service:
         previous_quarter = None
         self.has_previous_quarter = False
         
-        for quarter in self.valid_quarters:
+        for quarter in self.EXPECTED_QUARTERS:
             volume = as_number(self['%s_vol' % quarter])
             if volume is None:
                 continue
@@ -123,13 +124,14 @@ class Service:
 
     @property
     def data_coverage(self):
-        kpi_provided = lambda kpi: self._attributes_present(kpi,
-                                ['digital_volume_num', 'volume_num', 'cost'])
+        def count_provided_attributes(kpi):
+            return len([a for a in map(lambda attr: kpi[attr],
+                                       self.COVERAGE_ATTRIBUTES) if a is not None])
 
-        present = Decimal(len(filter(kpi_provided, self.kpis)))
-        total = Decimal(len(self.valid_quarters))
+        provided = sum(map(count_provided_attributes, self.kpis))
+        total = Decimal(len(self.EXPECTED_QUARTERS) * len(self.COVERAGE_ATTRIBUTES))
 
-        return present / total
+        return provided / total
 
     def _attributes_present(self, kpi, attrs):
         return all(kpi[attr] is not None for attr in attrs)

--- a/test/service/test_service.py
+++ b/test/service/test_service.py
@@ -105,12 +105,11 @@ class TestService(unittest.TestCase):
             '2012-Q4 Digital vol.': '10',
             u'2012-Q4 CPT (\xa3)': "2.00",
             "2013-Q1 Vol.": "2,000",
-            u'2013-Q1 CPT (\xa3)': "2.00",
             '2013-Q1 Digital vol.': '10',
             u'High-volume?': 'yes'
         }))
 
-        assert_that(float(service.data_coverage), close_to(0.6667, 0.001))
+        assert_that(float(service.data_coverage), close_to(0.5555, 0.001))
 
     def test_most_up_to_date_volume(self):
         service_with_one_vol = Service(details({'2013-Q1 Vol.': '200'}))


### PR DESCRIPTION
It takes into account the coverage attributes: ['digital_volume_num',
'volume_num', 'cost']
