### PR TITLE
Fix search in IE7 (reorder initSearch function)

### DIFF
--- a/assets/javascripts/search.js
+++ b/assets/javascripts/search.js
@@ -200,14 +200,12 @@ GOVUK.transactionsExplorer.getSearchKeyword = function (documentSearchString) {
 
 GOVUK.transactionsExplorer.initSearch = function () {
     $(function () {
-    GOVUK.transactionsExplorer.wireSearchForm({
-        formId: '#search',
-        inputId: '#search-box',
-        buttonId: '#search-button'
-        },
-        GOVUK.transactionsExplorer.search,
-        GOVUK.transactionsExplorer.getSearchKeyword(document.location.search));
-    GOVUK.transactionsExplorer.searchResultsTable.wireTable('#transactions-table');
+        GOVUK.transactionsExplorer.searchResultsTable.wireTable('#transactions-table');
+        GOVUK.transactionsExplorer.wireSearchForm({
+            formId: '#search',
+            inputId: '#search-box',
+            buttonId: '#search-button'},
+            GOVUK.transactionsExplorer.search,
+            GOVUK.transactionsExplorer.getSearchKeyword(document.location.search));
     });
 };
-


### PR DESCRIPTION
Previously, we were wiring the search form (and therefore doing a search on a `?keyword=`) before the results table existed. This caused an error in IE.

Now we're wiring the table before doing a search.
