### PR TITLE
Change page titles

### DIFF
--- a/templates/about-the-data.html
+++ b/templates/about-the-data.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% set current_navigation_link='about' %}
-{%  set title_prefix = 'About the data - ' %}
+{% set page_title = 'About the data' %}
 
 
 {% block body %}

--- a/templates/about-the-data.html
+++ b/templates/about-the-data.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 
 {% set current_navigation_link='about' %}
+{%  set title_prefix = 'About the data - ' %}
+
 
 {% block body %}
   <div class="group">

--- a/templates/all-services.html
+++ b/templates/all-services.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% set current_navigation_link='all-services' %}
+{% set page_title = 'All services' %}
 
 {% block body %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,8 @@
 <!--[if lt IE 9]><html class="lte-ie8 " lang="en"><![endif]--><!--[if gt IE 8]><!--><html lang="en" class="">
 <!--<![endif]--><head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>Transactions Explorer: transactional services data from the UK government</title>
+    <title>{{ title }}</title>
+    <!--{% block head %}{% endblock %}-->
     <script type="text/javascript">
         (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
     </script><!--[if gt IE 8]><!-->

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,10 @@
 <!--[if lt IE 9]><html class="lte-ie8 " lang="en"><![endif]--><!--[if gt IE 8]><!--><html lang="en" class="">
 <!--<![endif]--><head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>{{ title_prefix }}Transactions Explorer: transactional services performance data from the UK government</title>
+    <title>
+        {% set title_prefix = page_title + ' - ' if page_title is defined else '' %}
+        {{ title_prefix }}Transactions Explorer: transactional services performance data from the UK government
+    </title>
     <!--{% block head %}{% endblock %}-->
     <script type="text/javascript">
         (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,7 @@
 <!--[if lt IE 9]><html class="lte-ie8 " lang="en"><![endif]--><!--[if gt IE 8]><!--><html lang="en" class="">
 <!--<![endif]--><head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>{{ title }}</title>
+    <title>{{ title_prefix }}Transactions Explorer: transactional services performance data from the UK government</title>
     <!--{% block head %}{% endblock %}-->
     <script type="text/javascript">
         (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();

--- a/templates/department.html
+++ b/templates/department.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% set current_navigation_link='all-services' %}
+{% set page_title = department.name %}
 
 {% import "table_macros.html" as table %}
 

--- a/templates/high-volume-services.html
+++ b/templates/high-volume-services.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
-
 {% set current_navigation_link='high-volume-services' %}
+{%  set title_prefix = 'High volume services - ' %}
 
 {% block body %}
 

--- a/templates/high-volume-services.html
+++ b/templates/high-volume-services.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% set current_navigation_link='high-volume-services' %}
-{%  set title_prefix = 'High volume services - ' %}
+{% set page_title = 'High volume services' %}
 
 {% block body %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {%  set current_navigation_link = 'home' %}
+{%  set title = 'Transactions Explorer: transactional services performance data from the UK government' %}
 
 {% block body %}
     <header class="page-header group">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {%  set current_navigation_link = 'home' %}
-{%  set title = 'Transactions Explorer: transactional services performance data from the UK government' %}
 
 {% block body %}
     <header class="page-header group">

--- a/templates/service_detail.html
+++ b/templates/service_detail.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+        
+{% set page_title = service.name %}
 
 {% block body %}
   <header class="page-header group no-right-margin">


### PR DESCRIPTION
Adding title, as per: https://www.pivotaltracker.com/story/show/55466214
- overview/home - "Transactions Explorer: transactional services performance data from the UK government"
- high-vol : "High volume services - Transactions Explorer: transactional services performance data from the UK government"
- about the data : "About the data - Transactions Explorer: transactional services performance data from the UK government"
- specific transaction pages: eg tax disc  - "Tax disc - Transactions Explorer: transactional services performance data from the UK government"
- department pages: e.g. HMRC - "HM Revenue and Customs - Transactions Explorer: transactional services performance data from the UK government"
