### PR TITLE
Fix header image in Firefox

### DIFF
--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -1250,9 +1250,9 @@ header.page-header hgroup.te-image h2 {
 
 /* line 196, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/index.scss */
 header.page-header hgroup.te-image {
-  background: url(/transactions-explorer/images/TE_homepage_graphic.svg) no-repeat top left;
-  background-size: contain;
-  background-position-x: right; }
+  background: url(/transactions-explorer/images/TE_homepage_graphic.svg) no-repeat;
+  background-position: top right;
+  background-size: contain; }
 
 @media (max-width: 800px) {
   /* line 202, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/index.scss */


### PR DESCRIPTION
Sigh, fixing this for the second time.

`background-position-x` is not a CSS property. It is a nothing.
