### PR TITLE
Fix digital uptake change

### DIFF
--- a/lib/filters/__init__.py
+++ b/lib/filters/__init__.py
@@ -100,14 +100,14 @@ def number_as_percentage(num):
 
 
 def number_as_percentage_change(num):
-    if num == 0:
+    if num is None:
         return '0%'
     else:
-        num = ( num * 100 ) - 100
+        num = (num * 100) - 100
         if num == 0:
             return '0%'
         percentage = '%.2f' % num
-        return '%s%%' % percentage.rstrip('0.')
+        return '%s%%' % percentage.rstrip('0').rstrip('.')
 
 
 def number_as_grouped_number(num):

--- a/lib/filters/__init__.py
+++ b/lib/filters/__init__.py
@@ -102,12 +102,10 @@ def number_as_percentage(num):
 def number_as_percentage_change(num):
     if num is None:
         return '0%'
-    else:
-        num = (num * 100) - 100
-        if num == 0:
-            return '0%'
-        percentage = '%.2f' % num
-        return '%s%%' % percentage.rstrip('0').rstrip('.')
+
+    num = (num * 100) - 100
+    percentage = '%.2f' % num
+    return '%s%%' % percentage.rstrip('0').rstrip('.')
 
 
 def number_as_grouped_number(num):

--- a/lib/filters/__init__.py
+++ b/lib/filters/__init__.py
@@ -108,7 +108,7 @@ def number_as_percentage_change(num):
     if abs(num) < 0.01:
         return '0%'
 
-    percentage = '%.2f' % num
+    percentage = '%+.2f' % num
     return '%s%%' % percentage.rstrip('0').rstrip('.')
 
 

--- a/lib/filters/__init__.py
+++ b/lib/filters/__init__.py
@@ -2,6 +2,7 @@ from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 import locale
 
 from re import sub
+import math
 from lib.filters import digest
 
 
@@ -104,6 +105,9 @@ def number_as_percentage_change(num):
         return '0%'
 
     num = (num * 100) - 100
+    if abs(num) < 0.001:
+        return '0%'
+
     percentage = '%.2f' % num
     return '%s%%' % percentage.rstrip('0').rstrip('.')
 

--- a/lib/filters/__init__.py
+++ b/lib/filters/__init__.py
@@ -105,7 +105,7 @@ def number_as_percentage_change(num):
         return '0%'
 
     num = (num * 100) - 100
-    if abs(num) < 0.001:
+    if abs(num) < 0.01:
         return '0%'
 
     percentage = '%.2f' % num

--- a/templates/kpi_item.html
+++ b/templates/kpi_item.html
@@ -20,8 +20,9 @@
   </div>
   
   {% if change is not none %}
+  {% set change_string = change|as_percentage_change %}
     <div class="change col-35">
-      <h2 class="{% if change != 0 %}{% if change < 1 %}decrease {{decrease_class}}{% elif change > 1 %}increase {{increase_class}}{% endif %}{% endif %}">{{ change|as_percentage_change }}</h2>
+      <h2 class="{% if change_string != '0%' %}{% if change < 1 %}decrease {{decrease_class}}{% elif change > 1 %}increase {{increase_class}}{% endif %}{% endif %}">{{ change_string }}</h2>
       <h3>{{ kpis.get('previous_quarter') }}</h3>
     </div>
     <div class="previous clear-div">

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -114,9 +114,14 @@ def test_number_as_grouped_number():
 
 def test_number_as_percentage_change():
     assert_that(number_as_percentage_change(None), is_("0%"))
+    assert_that(number_as_percentage_change(1.0), is_("0%"))
+    assert_that(number_as_percentage_change(1.00001111), is_("0%"))
 
-    assert_that(number_as_percentage_change(0), is_("-100%"))
-    assert_that(number_as_percentage_change(2), is_("100%"))
+    assert_that(number_as_percentage_change(0.0), is_("-100%"))
+    assert_that(number_as_percentage_change(2.0), is_("100%"))
+
+    assert_that(number_as_percentage_change(1.1234567), is_("12.35%"))
+    assert_that(number_as_percentage_change(0.1234567), is_("-87.65%"))
 
 class Test_join_url_parts(object):
     def test_string_as_link(self):

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -119,9 +119,9 @@ def test_number_as_percentage_change():
     assert_that(number_as_percentage_change(0.999991), is_("0%"))
 
     assert_that(number_as_percentage_change(0.0), is_("-100%"))
-    assert_that(number_as_percentage_change(2.0), is_("100%"))
+    assert_that(number_as_percentage_change(2.0), is_("+100%"))
 
-    assert_that(number_as_percentage_change(1.1234567), is_("12.35%"))
+    assert_that(number_as_percentage_change(1.1234567), is_("+12.35%"))
     assert_that(number_as_percentage_change(0.1234567), is_("-87.65%"))
 
 class Test_join_url_parts(object):

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -115,7 +115,8 @@ def test_number_as_grouped_number():
 def test_number_as_percentage_change():
     assert_that(number_as_percentage_change(None), is_("0%"))
     assert_that(number_as_percentage_change(1.0), is_("0%"))
-    assert_that(number_as_percentage_change(1.00001111), is_("0%"))
+    assert_that(number_as_percentage_change(1.00001), is_("0%"))
+    assert_that(number_as_percentage_change(0.999991), is_("0%"))
 
     assert_that(number_as_percentage_change(0.0), is_("-100%"))
     assert_that(number_as_percentage_change(2.0), is_("100%"))

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -1,5 +1,5 @@
 from hamcrest import assert_that, is_
-from lib.filters import number_as_magnitude, number_as_financial_magnitude, join_url_parts, string_as_static_url, digest, number_as_grouped_number
+from lib.filters import number_as_magnitude, number_as_financial_magnitude, join_url_parts, string_as_static_url, digest, number_as_grouped_number, number_as_percentage_change
 
 
 def test_number_as_magnitude():
@@ -111,6 +111,12 @@ def test_number_as_grouped_number():
 
     assert_that(number_as_grouped_number("not a number"), is_(""))
 
+
+def test_number_as_percentage_change():
+    assert_that(number_as_percentage_change(None), is_("0%"))
+
+    assert_that(number_as_percentage_change(0), is_("-100%"))
+    assert_that(number_as_percentage_change(2), is_("100%"))
 
 class Test_join_url_parts(object):
     def test_string_as_link(self):


### PR DESCRIPTION
There were a few issues with the digital uptake calculation.
- 100% or -100% were not displayed correctly. 
- Numbers close to zero were displayed as blank.
- Should display + sign for positive change.
