### PR TITLE
Fix data coverage exclusion

### DIFF
--- a/create_pages.py
+++ b/create_pages.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
         ("by-department", lambda department: department.name),
         ("by-digital-takeup", lambda department: department.takeup),
         ("by-cost", lambda department: department.cost),
-        ("by-data-coverage", lambda department: department.data_coverage),
+        ("by-data-coverage", lambda department: department.data_coverage.percentage if department.data_coverage else None),
         ("by-transactions-per-year", lambda department: department.volume),
     ]
     generate_sorted_pages(departments, 'all-services', 'all-services', department_sort_orders)

--- a/lib/service/__init__.py
+++ b/lib/service/__init__.py
@@ -301,7 +301,7 @@ class Department(object):
         if total_services == 0:
             return None
         else:
-            return sum(service.data_coverage.percentage for service in high_volume_services) / total_services
+            return Coverage(sum(service.data_coverage.percentage for service in high_volume_services), total_services)
 
 
 class ServiceKpiAggregator(object):

--- a/lib/service/__init__.py
+++ b/lib/service/__init__.py
@@ -139,7 +139,7 @@ class Service:
         all_requested = filter(is_requested, all_attrs)
         all_provided = filter(is_provided, all_requested)
 
-        return Decimal(len(all_provided)) / Decimal(len(all_requested))
+        return Coverage(len(all_provided), len(all_requested))
 
     def _attributes_present(self, kpi, attrs):
         return all(kpi[attr] is not None for attr in attrs)
@@ -301,7 +301,7 @@ class Department(object):
         if total_services == 0:
             return None
         else:
-            return sum(service.data_coverage for service in high_volume_services) / total_services
+            return sum(service.data_coverage.percentage for service in high_volume_services) / total_services
 
 
 class ServiceKpiAggregator(object):
@@ -332,3 +332,13 @@ def total_transaction_volume(services):
         return number_of_transactions + memo
 
     return reduce(_sum, services, 0)
+
+
+class Coverage(object):
+    def __init__(self, provided, requested):
+        self.provided = provided
+        self.requested = requested
+
+    @property
+    def percentage(self):
+        return Decimal(self.provided) / Decimal(self.requested)

--- a/lib/service/__init__.py
+++ b/lib/service/__init__.py
@@ -324,13 +324,8 @@ class ServiceKpiAggregator(object):
 
 
 def total_transaction_volume(services):
-    def _sum(memo, service):
-        number_of_transactions = 0
-        if service.has_kpis:
-            number_of_transactions = service.latest_kpi_for('volume_num')
-        return number_of_transactions + memo
-
-    return reduce(_sum, services, 0)
+    volumes = filter(None, map(lambda s: s.most_up_to_date_volume, services))
+    return sum(volumes)
 
 
 class Coverage(object):

--- a/lib/service/__init__.py
+++ b/lib/service/__init__.py
@@ -296,12 +296,11 @@ class Department(object):
     @property
     def data_coverage(self):
         high_volume_services = filter(lambda s: s.high_volume, self.services)
-        total_services = len(high_volume_services)
-
-        if total_services == 0:
+        if len(high_volume_services) == 0:
             return None
-        else:
-            return Coverage(sum(service.data_coverage.percentage for service in high_volume_services), total_services)
+
+        coverages = map(lambda s: s.data_coverage, high_volume_services)
+        return reduce(lambda dept_cov, serv_cov: dept_cov + serv_cov, coverages)
 
 
 class ServiceKpiAggregator(object):
@@ -342,3 +341,6 @@ class Coverage(object):
     @property
     def percentage(self):
         return Decimal(self.provided) / Decimal(self.requested)
+
+    def __add__(self, other):
+        return Coverage(self.provided + other.provided, self.requested + other.requested)

--- a/lib/service/__init__.py
+++ b/lib/service/__init__.py
@@ -300,7 +300,7 @@ class Department(object):
             return None
 
         coverages = map(lambda s: s.data_coverage, high_volume_services)
-        return reduce(lambda dept_cov, serv_cov: dept_cov + serv_cov, coverages)
+        return sum(coverages, Coverage(0, 0))
 
 
 class ServiceKpiAggregator(object):

--- a/templates/department.html
+++ b/templates/department.html
@@ -26,7 +26,7 @@
 
     {% if department.high_volume_count > 0 %}
     <div id="data-coverage-notice" class="application-notice info-notice">
-        <h2>Department data coverage: {{ department.data_coverage|as_percentage }}</h2>
+        <h2>Department data coverage: {{ department.data_coverage.percentage|as_percentage if department.data_coverage}}</h2>
         <p>(taken from {{ department.high_volume_count }} high volume services)</p>
     </div>
     {% endif %}

--- a/templates/departments_table.html
+++ b/templates/departments_table.html
@@ -59,7 +59,7 @@
                 <th scope="row"><a href="{{ department.link|as_absolute_url }}">{{ department.name }}</a></th>
                 <td class="amount"> {{ department.takeup|as_percentage }} </td>
                 <td class="amount"> {{ table.money_cell(department.cost) }} </td>
-                <td class="amount"> {{ department.data_coverage|as_percentage }} </td>
+                <td class="amount"> {{ department.data_coverage.percentage|as_percentage if department.data_coverage }} </td>
                 <td class="amount"> {{ department.volume|as_grouped_number }} </td>
             </tr>
 

--- a/test/service/test_department.py
+++ b/test/service/test_department.py
@@ -353,6 +353,8 @@ class TestDepartmentDataCoverage(unittest.TestCase):
         coverage = dept.data_coverage
 
         assert_that(coverage.percentage, is_(0.5))
+        assert_that(coverage.requested, is_(18))
+        assert_that(coverage.provided, is_(9))
 
     def test_data_coverage_excludes_non_high_volume_services(self):
         services = [
@@ -379,6 +381,8 @@ class TestDepartmentDataCoverage(unittest.TestCase):
         coverage = dept.data_coverage
 
         assert_that(float(coverage.percentage), close_to(0.3333, 0.001))
+        assert_that(coverage.requested, is_(9))
+        assert_that(coverage.provided, is_(3))
 
     def test_data_coverage_is_none_when_no_high_volume_services(self):
         services = [
@@ -403,3 +407,29 @@ class TestDepartmentDataCoverage(unittest.TestCase):
 
         assert_that(dept.data_coverage, is_(None))
 
+    def test_data_coverage_when_quarter_not_provided(self):
+        services = [
+            Service(details({
+                "2012-Q4 Vol.": "2,000",
+                '2012-Q4 Digital vol.': '10',
+                u'2012-Q4 CPT (\xa3)': "2.00",
+                "2013-Q1 Vol.": "***",
+                u'2013-Q1 CPT (\xa3)': "***",
+                '2013-Q1 Digital vol.': '***',
+                u'High-volume?': 'yes'
+            })),
+            Service(details({
+                "2012-Q4 Vol.": "1,000",
+                u'2012-Q4 CPT (\xa3)': "3.00",
+                '2012-Q4 Digital vol.': '10',
+                u'High-volume?': 'yes'
+            })),
+        ]
+
+        dept = Department("Agengy for Beatiful Code", services)
+
+        coverage = dept.data_coverage
+
+        assert_that(float(coverage.percentage), close_to(0.4, 0.001))
+        assert_that(coverage.requested, is_(15))
+        assert_that(coverage.provided, is_(6))

--- a/test/service/test_department.py
+++ b/test/service/test_department.py
@@ -350,7 +350,9 @@ class TestDepartmentDataCoverage(unittest.TestCase):
 
         dept = Department("Agengy for Beatiful Code", services)
 
-        assert_that(dept.data_coverage, is_(0.5))
+        coverage = dept.data_coverage
+
+        assert_that(coverage.percentage, is_(0.5))
 
     def test_data_coverage_excludes_non_high_volume_services(self):
         services = [
@@ -374,7 +376,9 @@ class TestDepartmentDataCoverage(unittest.TestCase):
 
         dept = Department("Agengy for Beatiful Code", services)
 
-        assert_that(float(dept.data_coverage), close_to(0.3333, 0.001))
+        coverage = dept.data_coverage
+
+        assert_that(float(coverage.percentage), close_to(0.3333, 0.001))
 
     def test_data_coverage_is_none_when_no_high_volume_services(self):
         services = [

--- a/test/service/test_service.py
+++ b/test/service/test_service.py
@@ -110,7 +110,11 @@ class TestService(unittest.TestCase):
             u'High-volume?': 'yes'
         }))
 
-        assert_that(float(service.data_coverage), close_to(0.5555, 0.001))
+        coverage = service.data_coverage
+
+        assert_that(float(coverage.percentage), close_to(0.5555, 0.001))
+        assert_that(coverage.requested, is_(9))
+        assert_that(coverage.provided, is_(5))
 
     def test_coverage_with_non_requested_metrics(self):
         service = Service(details({
@@ -125,7 +129,11 @@ class TestService(unittest.TestCase):
         }))
 
         # 5 / 8
-        assert_that(float(service.data_coverage), close_to(0.625, 0.001))
+        coverage = service.data_coverage
+
+        assert_that(float(coverage.percentage), close_to(0.625, 0.001))
+        assert_that(coverage.requested, is_(8))
+        assert_that(coverage.provided, is_(5))
 
     def test_most_up_to_date_volume(self):
         service_with_one_vol = Service(details({'2013-Q1 Vol.': '200'}))


### PR DESCRIPTION
It shouldn't be the average of the service's data coverage, as the
values not provided skew the calculation. It should use the total
requested and provided
