### PR TITLE
Use shortened service as abbreviation for treemap

### DIFF
--- a/templates/department.html
+++ b/templates/department.html
@@ -87,7 +87,7 @@
                 {% if service.has_details_page %}
                     data-href="{{ service.link|as_absolute_url }}"
                 {% endif %}
-                data-label="{{ service.name }}"
+                data-label="{{ service.short_service_name }}"
                 data-title="{{ service.name }}"
                 data-text-color="#fff"
                 data-dept-class="{{ service.abbr }}">


### PR DESCRIPTION
When the treemap is displayed on smaller screens, the name of the service/department might not fit in the box. In that case, we try to fit the abbreviated name. However, we were only outputting the abbreviated data for departments, and not for services. This should fix that.
