### PR TITLE
Remove tabular data style for article body.

### DIFF
--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -43,7 +43,7 @@
     padding: 1em; } }
 /* line 14, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/index.scss */
 .service-details article h1 {
-  font-family: "ntatabularnumbers", "nta", Arial, sans-serif;
+  font-family: "nta", Arial, sans-serif;
   font-size: 36px;
   font-size: 3.6rem;
   line-height: 1.11111;
@@ -985,7 +985,7 @@
 /*layout overrides*/
 /* line 26, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/index.scss */
 article h1 {
-  font-family: "ntatabularnumbers", "nta", Arial, sans-serif;
+  font-family: "nta", Arial, sans-serif;
   font-size: 24px;
   font-size: 2.4rem;
   line-height: 1.25;
@@ -1911,7 +1911,6 @@ article .transactions-explorer-download a {
   }
 }
 
-article td, article p {
+article td {
     font-family: "ntatabularnumbers", "nta", Arial, sans-serif;
 }
-


### PR DESCRIPTION
It should still use it for tables, treemaps and metric numbers elsewhere.
