### PR TITLE
Use environment specific static manifest on deploy

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 echo "Building from version ${APPLICATION_VERSION}"
 
-export CLIENT_SECRETS="/etc/google/oauth/client_secrets.json" 
+export CLIENT_SECRETS="/etc/google/oauth/client_secrets.json"
 export OAUTH_TOKENS="/var/lib/google/oauth/drive.db"
 export PATH_PREFIX="/performance/transactions-explorer/"
 export TREEMAP_ARTEFACT_NAME="treemaps.tgz"
@@ -12,6 +12,6 @@ export TREEMAP_ARTEFACT_NAME="treemaps.tgz"
 
 ./build_treemaps.sh
 
-ASSET_PREFIX="https://assets-origin.preview.alphagov.co.uk/transactions-explorer" ARTEFACT_NAME="transactions-explorer-preview.tgz" ./build_artefact.sh
-ASSET_PREFIX="https://assets-origin.production.alphagov.co.uk/transactions-explorer" ARTEFACT_NAME="transactions-explorer-staging.tgz" ./build_artefact.sh
-ASSET_PREFIX="https://assets.digital.cabinet-office.gov.uk/transactions-explorer" ARTEFACT_NAME="transactions-explorer-production.tgz" ./build_artefact.sh
+ASSET_HOST="https://assets-origin.preview.alphagov.co.uk" ARTEFACT_NAME="transactions-explorer-preview.tgz" ./build_artefact.sh
+ASSET_HOST="https://assets-origin.production.alphagov.co.uk" ARTEFACT_NAME="transactions-explorer-staging.tgz" ./build_artefact.sh
+ASSET_HOST="https://assets.digital.cabinet-office.gov.uk" ARTEFACT_NAME="transactions-explorer-production.tgz" ./build_artefact.sh

--- a/build_artefact.sh
+++ b/build_artefact.sh
@@ -5,11 +5,14 @@ if [ -z "$VIRTUAL_ENV" ]; then
     exit 1
 fi
 
+# Download the environment-specific static manifest
+curl "${ASSET_HOST}/static/manifest.yml" > data/static-digests.yml
+
 mkdir -p artefacts
 mkdir -p output; rm -Rf output/*
 
 if [ -n "${PATH_PREFIX}" ]; then CREATE_ARGS="${CREATE_ARGS} --path-prefix ${PATH_PREFIX}"; fi
-if [ -n "${ASSET_PREFIX}" ]; then CREATE_ARGS="${CREATE_ARGS} --asset-prefix ${ASSET_PREFIX}"; fi
+if [ -n "${ASSET_HOST}" ]; then CREATE_ARGS="${CREATE_ARGS} --asset-prefix ${ASSET_HOST}/transactions-explorer"; fi
 CREATE_ARGS="${CREATE_ARGS} --static-digests data/static-digests.yml"
 
 python create_pages.py $CREATE_ARGS

--- a/fetch_data.sh
+++ b/fetch_data.sh
@@ -9,7 +9,3 @@ if [ -n "${CLIENT_SECRETS}" ]; then FETCH_ARGS="${FETCH_ARGS} --client-secrets $
 if [ -n "${OAUTH_TOKENS}" ];   then FETCH_ARGS="${FETCH_ARGS} --oauth-tokens ${OAUTH_TOKENS}"; fi
 
 python fetch_csv.py $FETCH_ARGS
-
-curl https://assets.digital.cabinet-office.gov.uk/static/manifest.yml > data/static-digests.yml
-
-


### PR DESCRIPTION
This will allow us to spot issues in static before it is deployed to production. As it was a few days ago.
