### PR TITLE
Historic transactions

### DIFF
--- a/create_pages.py
+++ b/create_pages.py
@@ -38,7 +38,7 @@ services = [Service(details=row) for row in reader]
 services_with_details = [service for service in services if service.has_details_page]
 
 high_volume_services = [service for service in services if service.high_volume]
-latest_quarter = latest_quarter(high_volume_services)
+latest_quarter = latest_quarter(services)
 
 departments = set(s.department for s in services)
 
@@ -52,6 +52,7 @@ def generate_sorted_pages(items, page_name, output_prefix, sort_orders, extra_va
                 'items': sorted_ignoring_empty_values(items, key=key,
                                                       reverse=reverse),
                 'treemap_url': treemap_url,
+                'latest_quarter': latest_quarter,
                 'current_sort': {
                     'order': sort_order,
                     'direction': direction
@@ -73,7 +74,8 @@ if __name__ == "__main__":
         render('service_detail.html',
                out="%s.html" % service.link,
                vars={'service': service,
-                     'department': Department(service.department, [service])})
+                     'department': Department(service.department, [service]),
+                     'latest_quarter': latest_quarter })
 
     sort_orders = [
         ("by-name", lambda service: service.name_of_service),
@@ -84,7 +86,7 @@ if __name__ == "__main__":
         ("by-transactions-per-year", lambda service: service.latest_kpi_for('volume_num')),
     ]
     generate_sorted_pages(high_volume_services, 'high-volume-services', 'high-volume-services',
-                          sort_orders, {'latest_quarter': latest_quarter})
+                          sort_orders)
 
     departments = Department.from_services(services)
     department_sort_orders = [

--- a/templates/department.html
+++ b/templates/department.html
@@ -107,7 +107,12 @@
                         <a rel="external" href="{{ service.url }}">Access service</a>
                     {% endif %}
                 </td>
-                <td class="amount"> {{ service.most_up_to_date_volume|as_grouped_number }} </td>
+                <td class="amount">
+                    {{ table.cell_content(quarter=service.latest_kpi_for('quarter'),
+                                    latest_quarter = latest_quarter,
+                                    value=service.most_up_to_date_volume,
+                                    cell_format=table.number_cell) }}
+                </td>
             </tr>
         {% endfor %}
 

--- a/templates/departments_table.html
+++ b/templates/departments_table.html
@@ -1,4 +1,12 @@
 
+{% macro cell_content(value, cell_format) -%}
+    {% if value != None -%}
+        {{ cell_format(value) }}
+    {%- else -%}
+        <span class="olddata" title="No data provided">*</span>
+    {%- endif %}
+{%- endmacro %}
+
 {% import "table_macros.html" as table %}
 
 <table id="transactions-table" class="full_width_table">
@@ -57,10 +65,26 @@
                 >
                 
                 <th scope="row"><a href="{{ department.link|as_absolute_url }}">{{ department.name }}</a></th>
-                <td class="amount"> {{ department.takeup|as_percentage }} </td>
-                <td class="amount"> {{ table.money_cell(department.cost) }} </td>
-                <td class="amount"> {{ department.data_coverage.percentage|as_percentage if department.data_coverage }} </td>
-                <td class="amount"> {{ department.volume|as_grouped_number }} </td>
+                <td class="amount">
+                    
+                    {{ cell_content(value=department.takeup,
+                                    cell_format=table.percentage_cell ) }}
+                </td>
+                <td class="amount">
+                    {{ cell_content(value=department.cost,
+                                    cell_format=table.money_cell ) }}
+                </td>
+                <td class="amount">
+                    {% if department.data_coverage != None -%}
+                        {{ cell_content(value=department.data_coverage.percentage, cell_format=table.percentage_cell ) }}
+                    {%- else -%}
+                        <span class="olddata" title="No data provided">*</span>
+                    {%- endif %}
+                </td>
+                <td class="amount">
+                    {{ cell_content(value=department.volume,
+                                    cell_format=table.number_cell ) }}
+                </td>
             </tr>
 
         {% endfor %}

--- a/templates/departments_table.html
+++ b/templates/departments_table.html
@@ -1,12 +1,3 @@
-
-{% macro cell_content(value, cell_format) -%}
-    {% if value != None -%}
-        {{ cell_format(value) }}
-    {%- else -%}
-        <span class="olddata" title="No data provided">*</span>
-    {%- endif %}
-{%- endmacro %}
-
 {% import "table_macros.html" as table %}
 
 <table id="transactions-table" class="full_width_table">
@@ -65,26 +56,10 @@
                 >
                 
                 <th scope="row"><a href="{{ department.link|as_absolute_url }}">{{ department.name }}</a></th>
-                <td class="amount">
-                    
-                    {{ cell_content(value=department.takeup,
-                                    cell_format=table.percentage_cell ) }}
-                </td>
-                <td class="amount">
-                    {{ cell_content(value=department.cost,
-                                    cell_format=table.money_cell ) }}
-                </td>
-                <td class="amount">
-                    {% if department.data_coverage != None -%}
-                        {{ cell_content(value=department.data_coverage.percentage, cell_format=table.percentage_cell ) }}
-                    {%- else -%}
-                        <span class="olddata" title="No data provided">*</span>
-                    {%- endif %}
-                </td>
-                <td class="amount">
-                    {{ cell_content(value=department.volume,
-                                    cell_format=table.number_cell ) }}
-                </td>
+                <td class="amount"> {{ department.takeup|as_percentage }} </td>
+                <td class="amount"> {{ table.money_cell(department.cost) }} </td>
+                <td class="amount"> {{ department.data_coverage.percentage|as_percentage if department.data_coverage }} </td>
+                <td class="amount"> {{ department.volume|as_grouped_number }} </td>
             </tr>
 
         {% endfor %}

--- a/templates/service_table.html
+++ b/templates/service_table.html
@@ -1,16 +1,3 @@
-
-{% macro cell_content(value, quarter, cell_format) -%}
-    {% if value != None -%}
-        {% if quarter < latest_quarter -%}
-            <span class="olddata" title="Data received {{ quarter }}; latest data not provided">{{ cell_format(value) }}*</span>
-        {%- else -%}
-            {{ cell_format(value) }}
-        {%- endif %}
-    {%- else -%}
-        <span class="olddata" title="No data provided">*</span>
-    {%- endif %}
-{%- endmacro %}
-
 {% import "table_macros.html" as table %}
 
 <table id="transactions-table" class="full_width_table">
@@ -78,25 +65,29 @@
                 <td><abbr title="{{ service.department }}">{{ service.abbr }}</abbr></td>
 
                 <td class="amount">
-                    {{ cell_content(quarter=service.latest_kpi_for('quarter'),
+                    {{ table.cell_content(quarter=service.latest_kpi_for('quarter'),
+                                    latest_quarter = latest_quarter,
                                     value=service.latest_kpi_for('cost'),
                                     cell_format=table.money_cell) }}
                 </td>
 
                 <td class="amount">
-                    {{ cell_content(quarter=service.latest_kpi_for('quarter'),
+                    {{ table.cell_content(quarter=service.latest_kpi_for('quarter'),
+                                    latest_quarter = latest_quarter,
                                     value=service.latest_kpi_for('cost_per_number'),
                                     cell_format=table.money_cell) }}
                 </td>
 
                 <td class="amount">
-                    {{ cell_content(quarter=service.latest_kpi_for('quarter'),
+                    {{ table.cell_content(quarter=service.latest_kpi_for('quarter'),
+                                    latest_quarter = latest_quarter,
                                     value=service.latest_kpi_for('takeup'),
                                     cell_format=table.percentage_cell) }}
                 </td>
 
                 <td class="amount">
-                    {{ cell_content(quarter=service.latest_kpi_for('quarter'),
+                    {{ table.cell_content(quarter=service.latest_kpi_for('quarter'),
+                                    latest_quarter = latest_quarter,
                                     value=service.latest_kpi_for('volume_num'),
                                     cell_format=table.number_cell) }}
                 </td>

--- a/templates/table_macros.html
+++ b/templates/table_macros.html
@@ -1,3 +1,15 @@
+{% macro cell_content(value, quarter, latest_quarter, cell_format) -%}
+    {% if value != None -%}
+        {% if quarter < latest_quarter -%}
+            <span class="olddata" title="Data received {{ quarter }}; latest data not provided">{{ cell_format(value) }}*</span>
+        {%- else -%}
+            {{ cell_format(value) }}
+        {%- endif %}
+    {%- else -%}
+        <span class="olddata" title="No data provided">*</span>
+    {%- endif %}
+{%- endmacro %}
+
 {% macro th_content(text, sort, current_sort, title=None, default_direction="ascending") -%}
     {% if sort != current_sort.order %}
         <a href="../{{ sort }}/{{ default_direction }}#transactions-table" title="{{ title }}">{{ text }}</a>

--- a/test/features/test_generate_department_pages.py
+++ b/test/features/test_generate_department_pages.py
@@ -37,7 +37,7 @@ class GenerateDepartmentPages(BrowserTest):
         assert_that(table, is_([
             [u'Service 1', u'GDS', u'Exciting service', u'Access service', u'4,820,000'],
             [u'Service 2', u'GDS', u'', u'', u'17,150'],
-            [u'Service 3', u'Another Government', u'Lame service', u'', u'2,141'],
+            [u'Service 3', u'Another Government', u'Lame service', u'', u'2,141*'],
         ]))
 
 


### PR DESCRIPTION
Adding cell_content macro to table_macros (taken from service_table template)
Making latest_quarter variable more available across templates

Department listing pages now display historic data in the same way as High Volume, red with an asterisk.
