### PR TITLE
Change title and add explanatory text to All Services page

### DIFF
--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -1925,3 +1925,13 @@ article .transactions-explorer-download a {
 article td {
     font-family: "ntatabularnumbers", "nta", Arial, sans-serif;
 }
+
+p.explanatory, #content header p.explanatory {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 24px;
+  line-height: 1.25;
+  font-weight: 400;
+  text-transform: none;
+  width: 65.625%;
+  margin-bottom: 0;
+}

--- a/templates/all-services.html
+++ b/templates/all-services.html
@@ -7,8 +7,13 @@
 
 <header class="page-header group">
     <hgroup>
-        <h1>All services</h1>
+        <h1>Transactions Explorer</h1>
     </hgroup>
+    <p class="explanatory">
+      Compare all government transactions grouped by the department providing them. You can also see just 
+      the <a href="{{ 'high-volume-services/by-transactions-per-year/descending'|as_absolute_url }}">high volume services</a>, 
+      or read more about <a href="{{ 'about-data'|as_absolute_url }}">how the data was collected</a>.
+    </p>
 </header>
 
 {% include "search_box.html" %}

--- a/test/features/test_create_pages.py
+++ b/test/features/test_create_pages.py
@@ -27,9 +27,6 @@ class test_create_pages(BrowserTest):
         assert_that(services, contains_string('10'))
         assert_that(transactions, contains_string('26.0m'))
 
-    @nottest
     def test_all_services(self):
-        self.browser.visit("http://0.0.0.0:8000/all-services")
-        assert_that(self.browser.find_by_css('#wrapper h1').text, is_("All Services"))
-        assert_that(self.browser.find_by_css('#navigation .current').text,
-                    is_("All services"))
+        self.browser.visit("http://0.0.0.0:8000/all-services/by-transactions-per-year/descending")
+        assert_that(self.browser.find_by_css('#wrapper h1').text, is_("Transactions Explorer"))

--- a/test/features/test_create_pages.py
+++ b/test/features/test_create_pages.py
@@ -30,3 +30,4 @@ class test_create_pages(BrowserTest):
     def test_all_services(self):
         self.browser.visit("http://0.0.0.0:8000/all-services/by-transactions-per-year/descending")
         assert_that(self.browser.find_by_css('#wrapper h1').text, is_("Transactions Explorer"))
+        assert_that(self.browser.find_by_css('.explanatory').text, is_("Compare all government transactions grouped by the department providing them. You can also see just the high volume services, or read more about how the data was collected."))


### PR DESCRIPTION
I haven't removed the homepage generation, since we will redirect / to the all services page
