### PR TITLE
Remove intro duplication on high volume page

### DIFF
--- a/templates/high-volume-services.html
+++ b/templates/high-volume-services.html
@@ -12,16 +12,13 @@
         <h1>High-volume services</h1>
     </hgroup>
     <p class="explanatory">
-      Compare all government transactions grouped by the department providing them. You can also see just 
-      the <a href="{{ 'high-volume-services/by-transactions-per-year/descending'|as_absolute_url }}">high volume services</a>, 
-      or read more about <a href="{{ 'about-data'|as_absolute_url }}">how the data was collected</a>.
+        You can also see <a href="{{ 'all-services/by-transactions-per-year/descending'|as_absolute_url }}">all services</a>, or read more about <a href="{{ 'about-data'|as_absolute_url }}">how the data was collected</a>.
     </p>
 </header>
 
 <div class="group">
     <article role="article" class="group">
         <section class="content-group">
-            <p class="explanatory">You can also see <a href="{{ 'all-services/by-transactions-per-year/descending'|as_absolute_url }}">all services</a>, or read more about <a href="{{ 'about-data'|as_absolute_url }}">how the data was collected</a>.</p>
 
             <h1>Annual volume of transactions by service</h1>
 


### PR DESCRIPTION
Linking to high volume services on the high volume services page is not useful.
