### PR TITLE
Fix for bug 62540700 - do not hide columns on small screens

### DIFF
--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -1868,17 +1868,11 @@ article .transactions-explorer-download a {
     font-size: 14px;
     padding:0.4em 0.2em 0.4em .5em;
   }
-  table th:nth-child(2),
-  table td:nth-child(2),
-  table th:nth-child(4),
-  table td:nth-child(4){
+  table.full_width_table th:nth-child(2),
+  table.full_width_table td:nth-child(2),
+  table.full_width_table th:nth-child(4),
+  table.full_width_table td:nth-child(4){
     display: none;
-  }
-  table.historical th:nth-child(2),
-  table.historical td:nth-child(2),
-  table.historical th:nth-child(4),
-  table.historical td:nth-child(4){
-    display: table-cell;
   }
 }
 

--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -1874,6 +1874,12 @@ article .transactions-explorer-download a {
   table td:nth-child(4){
     display: none;
   }
+  table.historical th:nth-child(2),
+  table.historical td:nth-child(2),
+  table.historical th:nth-child(4),
+  table.historical td:nth-child(4){
+    display: table-cell;
+  }
 }
 
 .page-title {

--- a/templates/kpi_item.html
+++ b/templates/kpi_item.html
@@ -28,7 +28,7 @@
     <div class="previous clear-div">
       <details>
         <summary role="button" aria-expanded="false">Historical data</summary>
-        <table>
+        <table class="historical">
           {% for previous in service.historical_data_before(quarter, key) %}
             <tr>
               <th>{{previous.quarter}}</th>

--- a/templates/kpi_item.html
+++ b/templates/kpi_item.html
@@ -28,7 +28,7 @@
     <div class="previous clear-div">
       <details>
         <summary role="button" aria-expanded="false">Historical data</summary>
-        <table class="historical">
+        <table>
           {% for previous in service.historical_data_before(quarter, key) %}
             <tr>
               <th>{{previous.quarter}}</th>


### PR DESCRIPTION
Ralph hid these four months ago due to a compromise fix on full width table. This fixes the side effect - nothing should be hidden on non full width tables.
