### PR TITLE
Show old data box on search and department pages

### DIFF
--- a/create_pages.py
+++ b/create_pages.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     json_map = map_services_to_dicts(services)
     render_search_json(json_map, 'data/search.json')
 
-    render('search.html', 'search.html', {})
+    render('search.html', 'search.html', {'latest_quarter': latest_quarter})
 
     # Copy the assets folder entirely, as well
     dir_util.copy_tree('assets', '%s/transactions-explorer' % OUTPUT_DIR)

--- a/templates/department.html
+++ b/templates/department.html
@@ -127,6 +127,8 @@
             {% include "treemap_javascript.html" %}
         {% endwith %}
 
+        {% include "old_data_infobox.html" %}
+
         {% include "csv_download_link.html" %}
 
         </section>

--- a/templates/high-volume-services.html
+++ b/templates/high-volume-services.html
@@ -32,9 +32,7 @@
                 {% include "treemap_javascript.html" %}
             {% endwith %}
 
-            <div id="old-data" class="application-notice info-notice table-margin">
-                <p>*{{ latest_quarter }} data not provided for this metric; previous quarter's metric shown if available. See service page for information on obtaining latest data</p>
-            </div>
+            {% include "old_data_infobox.html" %}
 
             {% include "csv_download_link.html" %}
 

--- a/templates/old_data_infobox.html
+++ b/templates/old_data_infobox.html
@@ -1,0 +1,3 @@
+<div id="old-data" class="application-notice info-notice table-margin">
+    <p>*{{ latest_quarter }} data not provided for this metric; previous quarter's metric shown if available. See service page for information on obtaining latest data.</p>
+</div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -42,6 +42,8 @@
 
     </div>
 
+    {% include "old_data_infobox.html" %}
+
     {% include "csv_download_link.html" %}
 
     </section>

--- a/test/features/__init__.py
+++ b/test/features/__init__.py
@@ -15,7 +15,7 @@ def teardown_package():
 @attr('feature')
 class BrowserTest(TestCase):
     def setUp(self):
-        self.browser = Browser('phantomjs', wait_time=3)
+        self.browser = Browser('phantomjs', wait_time=10)
         self.browser.driver.set_window_size(1024, 768)
 
     def tearDown(self):


### PR DESCRIPTION
Bring it out into an include to reuse it. Pass the `latest_quarter` variable into the search template.
