### PR TITLE
Force table cells containing department names to expand.

### DIFF
--- a/assets/stylesheets/index.css
+++ b/assets/stylesheets/index.css
@@ -1308,7 +1308,13 @@ table.full_width_table {
 #transactions-table tbody th {
   background: #eaedef;
   border: dotted 1px #b8c6cc;
-  font-weight: normal; }
+  font-weight: normal; 
+  white-space: nowrap; }
+  
+@media (max-width: 860px) {
+  #transactions-table tbody th {
+    white-space: normal;
+} }
 
 /* line 253, /mnt/jenkins/workspace/innovations-transactions-visualisation/web/app/assets/stylesheets/index.scss */
 #transactions-table tbody tr:nth-child(even) th {


### PR DESCRIPTION
Improve ugly wrapping text by forcing first table cell to expand to the width of the department name.

Revert to normal wrapping behaviour at 860px screen width, otherwise table becomes too wide for the screen.

Pivotal: https://www.pivotaltracker.com/s/projects/911874/stories/62541068
