### PR TITLE
Remove service page reference from old data box

### DIFF
--- a/templates/old_data_infobox.html
+++ b/templates/old_data_infobox.html
@@ -1,3 +1,3 @@
 <div id="old-data" class="application-notice info-notice table-margin">
-    <p>*{{ latest_quarter }} data not provided for this metric; previous quarter's metric shown if available. See service page for information on obtaining latest data.</p>
+    <p>*{{ latest_quarter }} data not provided for this metric; previous quarter's metric shown if available.</p>
 </div>


### PR DESCRIPTION
We no longer have this information on our new Spotlight service pages, because it hasn't been implemented yet, so remove this reference from Transactions Explorer.
